### PR TITLE
Nunjucks Style Comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       },
       {
         "id": "html",
+        "configuration": "./src/language/html.language-configuration.json",
         "extensions": [
           ".njk",
           ".nunjucks"

--- a/src/language/html.language-configuration.json
+++ b/src/language/html.language-configuration.json
@@ -1,0 +1,6 @@
+{
+  "comments": {
+    // symbols used for single line comments as well as start and end a block comment.
+    "blockComment": ["{#", "#}"]
+  }
+}

--- a/src/snippets/nunjucks-snippets.json
+++ b/src/snippets/nunjucks-snippets.json
@@ -143,5 +143,10 @@
     "prefix": "cblock",
     "body": "{# \n\t${1:comment}\n#}\n",
     "description": "Nunjucks Comment"
+  },
+  "HTML Comment": {
+    "prefix": "hcomm",
+    "body": "<!-- \n\t${1:htmlComment}\n-->\n",
+    "description": "HTML Comment"
   }
 }


### PR DESCRIPTION
Fixes #1

The behavior now includes nunjucks comments when using `ctrl+/` or `cmd+/`

Please Note: This might introduce unwanted behavior inside of files with a `.html` when adding comments - it is hard to determine what kind of comment the user might want to insert.

So my current workaround is to add HTML comments to the snippets, using the prefix `hcomm` 