### PR TITLE
Use Nunjucks-style comments in Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,13 @@
           ".njk",
           ".nunjucks"
         ]
+      },
+      {
+        "id": "markdown",
+        "configuration": "./src/language/markdown.language-configuration.json",
+        "extensions": [
+          ".md"
+        ]
       }
     ],
     "grammars": [

--- a/src/language/markdown.language-configuration.json
+++ b/src/language/markdown.language-configuration.json
@@ -1,0 +1,6 @@
+{
+  "comments": {
+    // symbols used for single line comments as well as start and end a block comment.
+    "blockComment": ["{#", "#}"]
+  }
+}


### PR DESCRIPTION
Uses Nunjucks-style syntax for comment shortcuts (`Ctrl + /`, etc.) in `.md` files to match current behavior in `.html` and `.njk` files.